### PR TITLE
fix: both bots get deployed when we push on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - test
 
 jobs:
   unit-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,8 @@ jobs:
         with:
           service-id: ${{ secrets.RENDER_SERVICE_ID }}
           api-key: ${{ secrets.RENDER_API_KEY }}
+      - name: Deploy to PartitelleBotTest
+        uses: johnbeynon/render-deploy-action@v0.0.8
+        with:
+          service-id: ${{ secrets.RENDER_TEST_SERVICE_ID }}
+          api-key: ${{ secrets.RENDER_TEST_API_KEY }}


### PR DESCRIPTION
## What
update CI to deploy on PartitelleBot and PartitelleBotTest when pushing on `main` branch

## How
By updating `workflows/main.yml`
