### PR TITLE
chore: add tests to main CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,10 @@
 name: Unit Tests
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+  pull_request:
 
 jobs:
   unit-test:


### PR DESCRIPTION
## What
tests CI step was running only on PR, now it runs also on push

## Checklist
- [ ] I have deployed to PartitelleBotTest by adding `deploy-partitellebot-test` label in the PR and checked that it works
